### PR TITLE
On Linux platforms add a required dependency on libdl.so for the sqli…

### DIFF
--- a/sqlite/CMakeLists.txt
+++ b/sqlite/CMakeLists.txt
@@ -1,2 +1,6 @@
 set ( Sqlite_srcs sqlite3.c )
 add_library ( sqlite3 ${Sqlite_srcs} )
+
+if (${UNIX})
+target_link_libraries(sqlite3 PUBLIC dl)
+endif (${UNIX})


### PR DESCRIPTION
Add the libdl.so lib for sqlite when building in Linux.
